### PR TITLE
Add a timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,24 @@ const upfetch = up(fetch, () => ({
 }))
 ```
 
+### ✔️ Timeout
+
+Set a default timeout for all requests:
+
+```ts
+const upfetch = up(fetch, () => ({
+   timeout: 5000,
+}))
+```
+
+Use a different timeout for a specific request:
+
+```ts
+upfetch('/todos', {
+   timeout: 3000,
+})
+```
+
 ### ✔️ Error Handling
 
 By default, _up-fetch_ throws a `ResponseError` when `response.ok` is `false`. \
@@ -172,26 +190,6 @@ try {
 Use the [throwResponseError][api-reference] option to decide **when** to throw, or the [parseResponseError][api-reference] option to customize **what** to throw.
 
 ## Usage
-
-### ✔️ Timeouts
-
-While _up-fetch_ doesn't provide a timeout option, you can easily implement one using the [AbortSignal.timeout](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout) method:
-
-Set a default timeout for all requests:
-
-```ts
-const upfetch = up(fetch, () => ({
-   signal: AbortSignal.timeout(5000),
-}))
-```
-
-Use a different timeout for a specific request:
-
-```ts
-upfetch('/todos', {
-   signal: AbortSignal.timeout(3000),
-})
-```
 
 ### ✔️ Authentication
 
@@ -325,6 +323,7 @@ function up(
 | `parseResponseError`             | `(response, options) => error` | The default error response parser. <br/>If omitted `json` and `text` response are parsed automatically    |
 | `serializeBody`                  | `(body) => BodyInit`           | The default body serializer.                                                                              |
 | `serializeParams`                | `(params) => string`           | The default query parameter serializer.                                                                   |
+| `timeout`                        | `number`                       | The default timeout in milliseconds.                                                                      |
 | `throwResponseError`             | `(response) => boolean`        | Decide when to reject the response.                                                                       |
 | _...and all other fetch options_ |                                |                                                                                                           |
 
@@ -350,6 +349,7 @@ Options:
 | `schema`                         | `StandardSchemaV1`             | The schema to validate the response against.<br/>The schema must follow the [Standard Schema Specification][standard-schema]. |
 | `serializeBody`                  | `(body) => BodyInit`           | The body serializer.                                                                                                          |
 | `serializeParams`                | `(params) => string`           | The query parameter serializer.                                                                                               |
+| `timeout`                        | `number`                       | The timeout in milliseconds.                                                                                                  |
 | `throwResponseError`             | `(response) => boolean`        | Decide when to reject the response.                                                                                           |
 | _...and all other fetch options_ |                                |                                                                                                                               |
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Fetch API configuration tool with built-in validation and sensible defaults.
 
 ## ➡️ Highlights
 
-- 🚀 **Lightweight** - 1kB gzipped, no dependency
+- 🚀 **Lightweight** - 1.2kB gzipped, no dependency
 - 🛠️ **Practical API** - Use objects for `params` and `body`, get parsed responses automatically
 - 🎨 **Flexible Config** - Set defaults like `baseUrl` or `headers` once, use everywhere
 - 🔒 **Type Safe** - Validate API responses with [zod][zod], [valibot][valibot] or [arktype][arktype]

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
    "license": "MIT",
    "devDependencies": {
       "@eslint/js": "^9.19.0",
+      "@types/node": "^22.13.0",
       "eslint": "^9.19.0",
       "eslint-plugin-prefer-let": "^4.0.0",
       "jsdom": "^26.0.0",

--- a/src/resolve-options.spec.ts
+++ b/src/resolve-options.spec.ts
@@ -128,6 +128,6 @@ test('options overrides', () => {
    expect('redirect' in resolved).toBeFalsy()
    expect('referrer' in resolved).toBeFalsy()
    expect('referrerPolicy' in resolved).toBeFalsy()
-   expect('signal' in resolved).toBeFalsy()
+   expect('signal' in resolved).toBeTruthy() // there is always a signal
    expect('window' in resolved).toBeFalsy()
 })

--- a/src/resolve-options.ts
+++ b/src/resolve-options.ts
@@ -58,6 +58,13 @@ export let resolveOptions = <
       params,
       rawBody,
       body,
+      signal: AbortSignal.any(
+         [
+            typeof mergedOptions.timeout === 'number' &&
+               AbortSignal.timeout(mergedOptions.timeout),
+            mergedOptions.signal as AbortSignal | undefined,
+         ].filter(Boolean) as AbortSignal[],
+      ),
       input: getUrl(
          mergedOptions.baseUrl,
          input,

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,10 +89,11 @@ export type ResolvedOptions<
    parseResponse: ParseResponse<TFetchFn, TParsedData>
    parseResponseError: ParseResponseError<TFetchFn>
    rawBody?: RawBody
+   schema?: TSchema
    serializeBody: SerializeBody
    serializeParams: SerializeParams
+   signal: AbortSignal
    throwResponseError: (response: Response) => MaybePromise<boolean>
-   schema?: TSchema
 }
 
 export type DefaultOptions<TFetchFn extends BaseFetchFn> =
@@ -107,6 +108,7 @@ export type DefaultOptions<TFetchFn extends BaseFetchFn> =
       serializeBody?: SerializeBody
       serializeParams?: SerializeParams
       throwResponseError?: (response: Response) => MaybePromise<boolean>
+      timeout?: number
    }
 
 export type FetcherOptions<
@@ -119,8 +121,9 @@ export type FetcherOptions<
    params?: Params
    parseResponse?: ParseResponse<TFetchFn, TParsedData>
    parseResponseError?: ParseResponseError<TFetchFn>
+   schema?: TSchema
    serializeBody?: SerializeBody
    serializeParams?: SerializeParams
    throwResponseError?: (response: Response) => MaybePromise<boolean>
-   schema?: TSchema
+   timeout?: number
 }


### PR DESCRIPTION
This PR adds a timeout option.

The timeout signal is automatically merged with the signal option using `AbortSignal.any`