### PR TITLE
fix: add null checks to error type guards

### DIFF
--- a/src/response-error.ts
+++ b/src/response-error.ts
@@ -26,4 +26,4 @@ export let isResponseError = <
 >(
    error: any,
    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-): error is ResponseError<TData, TFetchFn> => error.name === 'ResponseError'
+): error is ResponseError<TData, TFetchFn> => error?.name === 'ResponseError'

--- a/src/validation-error.ts
+++ b/src/validation-error.ts
@@ -15,4 +15,4 @@ export class ValidationError<TData = any> extends Error {
 
 export let isValidationError = (error: any): error is ValidationError =>
    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-   error.name === 'ValidationError'
+   error?.name === 'ValidationError'


### PR DESCRIPTION
Hi

This PR adds null checks to the type guards `isResponseError` and `isValidationError`.
I noticed these functions throw an error when the provided parameter is `null` or `undefined`, instead of returning `false`.