### PR TITLE
deprecate: throwResponseError and parseResponseError

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ try {
 }
 ```
 
-- Use the [parseResponseError][api-reference] option to throw a custom error instead.
-- Use the [throwResponseError][api-reference] option to decide **when** to throw.
+- Use the [parseRejected][api-reference] option to throw a custom error instead.
+- Use the [reject][api-reference] option to decide **when** to throw.
 
 #### 👉 <samp>ValidationError</samp>
 
@@ -357,12 +357,12 @@ const fetchText = up(fetch, () => ({
 
 While the Fetch API does not throw an error when the response is not ok, _upfetch_ throws a `ResponseError` instead.
 
-If you'd rather handle errors as values, set `throwResponseError` to return `false`. \
+If you'd rather handle errors as values, set `reject` to return `false`. \
 This allows you to customize the `parseResponse` function to return both successful data and error responses in a structured format.
 
 ```ts
 const upfetch = up(fetch, () => ({
-   throwResponseError: () => false,
+   reject: () => false,
    parseResponse: async (response) => {
       const json = await response.json()
       return response.ok
@@ -382,7 +382,7 @@ const { data, error } = await upfetch('/users/1')
 
 By default _upfetch_ is able to parse `json` and `text` sucessful responses automatically.
 
-The `parseResponse` method is called when `throwResponseError` returns `false`.
+The `parseResponse` method is called when `reject` returns `false`.
 You can use that option to parse other response types.
 
 ```ts
@@ -391,17 +391,17 @@ const upfetch = up(fetch, () => ({
 }))
 ```
 
-💡 Note that the `parseResponse` method is called only when `throwResponseError` returns `false`.
+💡 Note that the `parseResponse` method is called only when `reject` returns `false`.
 
 ### ✔️ Custom response errors
 
-By default _upfetch_ throws a `ResponseError` when `throwResponseError` returns `true`.
+By default _upfetch_ throws a `ResponseError` when `reject` returns `true`.
 
-If you want to throw a custom error instead, you can pass a function to the `parseResponseError` option.
+If you want to throw a custom error instead, you can pass a function to the `parseRejected` option.
 
 ```ts
 const upfetch = up(fetch, () => ({
-   parseResponseError: async (response) => {
+   parseRejected: async (response) => {
       const status = response.status
       const data = await response.json()
       return new CustomError(status, data)
@@ -511,11 +511,11 @@ function up(
 | `onError`                        | `(error, options) => void`     | Executes on error.                                                                                        |
 | `onSuccess`                      | `(data, options) => void`      | Executes when the request successfully completes.                                                         |
 | `parseResponse`                  | `(response, options) => data`  | The default success response parser. <br/>If omitted `json` and `text` response are parsed automatically. |
-| `parseResponseError`             | `(response, options) => error` | The default error response parser. <br/>If omitted `json` and `text` response are parsed automatically    |
+| `parseRejected`                  | `(response, options) => error` | The default error response parser. <br/>If omitted `json` and `text` response are parsed automatically    |
 | `serializeBody`                  | `(body) => BodyInit`           | The default body serializer.<br/> Restrict the valid `body` type by typing its first argument.            |
 | `serializeParams`                | `(params) => string`           | The default query parameter serializer.                                                                   |
 | `timeout`                        | `number`                       | The default timeout in milliseconds.                                                                      |
-| `throwResponseError`             | `(response) => boolean`        | Decide when to reject the response.                                                                       |
+| `reject`                         | `(response) => boolean`        | Decide when to reject the response.                                                                       |
 | _...and all other fetch options_ |                                |                                                                                                           |
 
 ### <samp>upfetch(url, options?)</samp>
@@ -536,12 +536,12 @@ Options:
 | `baseUrl`                        | `string`                       | Base URL for the request.                                                                                                     |
 | `params`                         | `object`                       | The query parameters.                                                                                                         |
 | `parseResponse`                  | `(response, options) => data`  | The success response parser.                                                                                                  |
-| `parseResponseError`             | `(response, options) => error` | The error response parser.                                                                                                    |
+| `parseRejected`                  | `(response, options) => error` | The error response parser.                                                                                                    |
 | `schema`                         | `StandardSchemaV1`             | The schema to validate the response against.<br/>The schema must follow the [Standard Schema Specification][standard-schema]. |
 | `serializeBody`                  | `(body) => BodyInit`           | The body serializer.<br/> Restrict the valid `body` type by typing its first argument.                                        |
 | `serializeParams`                | `(params) => string`           | The query parameter serializer.                                                                                               |
 | `timeout`                        | `number`                       | The timeout in milliseconds.                                                                                                  |
-| `throwResponseError`             | `(response) => boolean`        | Decide when to reject the response.                                                                                           |
+| `reject`                         | `(response) => boolean`        | Decide when to reject the response.                                                                                           |
 | _...and all other fetch options_ |                                |                                                                                                                               |
 
 <br/>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -234,8 +234,8 @@ try {
 }
 ```
 
-- 使用 [parseResponseError][api-reference] 选项抛出自定义错误。
-- 使用 [throwResponseError][api-reference] 选项决定**何时**抛出错误。
+- 使用 [parseRejected][api-reference] 选项抛出自定义错误。
+- 使用 [reject][api-reference] 选项决定**何时**抛出错误。
 
 #### 👉 <samp>ValidationError</samp>
 
@@ -360,12 +360,12 @@ const fetchText = up(fetch, () => ({
 
 虽然 Fetch API 在响应不正常时不会抛出错误，但 _upfetch_ 会抛出 `ResponseError`。
 
-如果你更愿意将错误作为值处理，将 `throwResponseError` 设置为返回 `false`。\
+如果你更愿意将错误作为值处理，将 `reject` 设置为返回 `false`。\
 这允许你自定义 `parseResponse` 函数以结构化格式返回成功数据和错误响应。
 
 ```ts
 const upfetch = up(fetch, () => ({
-   throwResponseError: () => false,
+   reject: () => false,
    parseResponse: async (response) => {
       const json = await response.json()
       return response.ok
@@ -385,7 +385,7 @@ const { data, error } = await upfetch('/users/1')
 
 默认情况下，_upfetch_ 能够自动解析 `json` 和 `text` 成功响应。
 
-当 `throwResponseError` 返回 `false` 时调用 `parseResponse` 方法。
+当 `reject` 返回 `false` 时调用 `parseResponse` 方法。
 你可以使用该选项解析其他响应类型。
 
 ```ts
@@ -394,17 +394,17 @@ const upfetch = up(fetch, () => ({
 }))
 ```
 
-💡 注意，只有当 `throwResponseError` 返回 `false` 时才会调用 `parseResponse` 方法。
+💡 注意，只有当 `reject` 返回 `false` 时才会调用 `parseResponse` 方法。
 
 ### ✔️ 自定义响应错误
 
-默认情况下，当 `throwResponseError` 返回 `true` 时，_upfetch_ 会抛出 `ResponseError`。
+默认情况下，当 `reject` 返回 `true` 时，_upfetch_ 会抛出 `ResponseError`。
 
-如果你想抛出自定义错误，可以向 `parseResponseError` 选项传递一个函数。
+如果你想抛出自定义错误，可以向 `parseRejected` 选项传递一个函数。
 
 ```ts
 const upfetch = up(fetch, () => ({
-   parseResponseError: async (response) => {
+   parseRejected: async (response) => {
       const status = response.status
       const data = await response.json()
       return new CustomError(status, data)
@@ -514,11 +514,11 @@ function up(
 | `onError`                    | `(error, options) => void`     | 发生错误时执行。                                                        |
 | `onSuccess`                  | `(data, options) => void`      | 请求成功完成时执行。                                                    |
 | `parseResponse`              | `(response, options) => data`  | 默认成功响应解析器。<br/>如果省略，将自动解析 `json` 和 `text` 响应。   |
-| `parseResponseError`         | `(response, options) => error` | 默认错误响应解析器。<br/>如果省略，将自动解析 `json` 和 `text` 响应。   |
+| `parseRejected`              | `(response, options) => error` | 默认错误响应解析器。<br/>如果省略，将自动解析 `json` 和 `text` 响应。   |
 | `serializeBody`              | `(body) => BodyInit`           | 默认请求体序列化器。<br/>通过类型化其第一个参数限制有效的 `body` 类型。 |
 | `serializeParams`            | `(params) => string`           | 默认查询参数序列化器。                                                  |
 | `timeout`                    | `number`                       | 默认超时时间（毫秒）。                                                  |
-| `throwResponseError`         | `(response) => boolean`        | 决定何时拒绝响应。                                                      |
+| `reject`                     | `(response) => boolean`        | 决定何时拒绝响应。                                                      |
 | _...以及所有其他 fetch 选项_ |                                |                                                                         |
 
 ### <samp>upfetch(url, options?)</samp>
@@ -539,12 +539,12 @@ function upfetch(
 | `baseUrl`                    | `string`                       | 请求的基础 URL。                                                                         |
 | `params`                     | `object`                       | 查询参数。                                                                               |
 | `parseResponse`              | `(response, options) => data`  | 成功响应解析器。                                                                         |
-| `parseResponseError`         | `(response, options) => error` | 错误响应解析器。                                                                         |
+| `parseRejected`              | `(response, options) => error` | 错误响应解析器。                                                                         |
 | `schema`                     | `StandardSchemaV1`             | 用于验证响应的模式。<br/>模式必须遵循 [Standard Schema Specification][standard-schema]。 |
 | `serializeBody`              | `(body) => BodyInit`           | 请求体序列化器。<br/>通过类型化其第一个参数限制有效的 `body` 类型。                      |
 | `serializeParams`            | `(params) => string`           | 查询参数序列化器。                                                                       |
 | `timeout`                    | `number`                       | 超时时间（毫秒）。                                                                       |
-| `throwResponseError`         | `(response) => boolean`        | 决定何时拒绝响应。                                                                       |
+| `reject`                     | `(response) => boolean`        | 决定何时拒绝响应。                                                                       |
 | _...以及所有其他 fetch 选项_ |                                |                                                                                          |
 
 <br/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "up-fetch",
-   "version": "1.3.3",
+   "version": "1.3.4-beta.1",
    "description": "Advanced fetch client builder for typescript.",
    "type": "module",
    "main": "dist/index.cjs",

--- a/src/fallback-options.spec.ts
+++ b/src/fallback-options.spec.ts
@@ -38,7 +38,7 @@ describe('parseResponse', () => {
    })
 })
 
-describe('parseResponseError', () => {
+describe('parseRejected', () => {
    test.each`
       response                                                       | output
       ${new Response('{ "a": true, "b": false, "c":"aaa", "d":1 }')} | ${{ a: true, b: false, c: 'aaa', d: 1 }}
@@ -46,11 +46,13 @@ describe('parseResponseError', () => {
       ${new Response()}                                              | ${null}
       ${new Response('')}                                            | ${null}
       ${new Response('<h1>Some text</h1>')}                          | ${'<h1>Some text</h1>'}
-   `('parseResponseError: $response', async ({ response, output }) => {
-      let responseError: ResponseError =
-         await fallbackOptions.parseResponseError(response, {
+   `('parseRejected: $response', async ({ response, output }) => {
+      let responseError: ResponseError = await fallbackOptions.parseRejected(
+         response,
+         {
             href: 'my-options',
-         } as any)
+         } as any,
+      )
       expect(responseError instanceof ResponseError).toBeTruthy()
       expect(responseError.data).toStrictEqual(output)
       expect(responseError.response).toStrictEqual(response)

--- a/src/fallback-options.ts
+++ b/src/fallback-options.ts
@@ -10,7 +10,7 @@ export let fallbackOptions: FallbackOptions<any> = {
          .catch(() => res.text())
          .then((data) => data || null),
 
-   parseResponseError: async (res, options) =>
+   parseRejected: async (res, options) =>
       new ResponseError(
          res,
          await fallbackOptions.parseResponse(res, options),
@@ -27,5 +27,5 @@ export let fallbackOptions: FallbackOptions<any> = {
    serializeBody: (body: any) =>
       isJsonifiable(body) ? JSON.stringify(body) : body,
 
-   throwResponseError: (response) => !response.ok,
+   reject: (response) => !response.ok,
 }

--- a/src/resolve-options.spec.ts
+++ b/src/resolve-options.spec.ts
@@ -90,6 +90,7 @@ test('options overrides', () => {
       method: 'PATCH',
       mode: 'navigate',
       params: { c: 'd' },
+      parseRejected: () => {},
       parseResponse: () => {},
       parseResponseError: () => {},
       priority: 'high',
@@ -98,6 +99,7 @@ test('options overrides', () => {
       referrerPolicy: 'no-referrer-when-downgrade',
       signal: new AbortController().signal,
       throwResponseError: () => true,
+      reject: () => true,
       window: null,
    }
    let fetcherOptions: FetcherOptions<typeof fetch, any, any, any> = {

--- a/src/resolve-options.ts
+++ b/src/resolve-options.ts
@@ -51,6 +51,22 @@ export let resolveOptions = <
          ? (rawBody as null | undefined)
          : mergedOptions.serializeBody(rawBody)
 
+   // throwResponseError will be renamed reject in v2.0
+   let reject =
+      fetcherOpts.reject ??
+      fetcherOpts.throwResponseError ??
+      defaultOptions.reject ??
+      defaultOptions.throwResponseError ??
+      fallbackOptions.reject
+
+   // parseResponseError will be renamed parseRejected in v2.0
+   let parseRejected =
+      fetcherOpts.parseRejected ??
+      fetcherOpts.parseResponseError ??
+      defaultOptions.parseRejected ??
+      defaultOptions.parseResponseError ??
+      fallbackOptions.parseRejected
+
    return stripUndefined({
       // I have to cast as mergedOptions because the type breaks with omit
       ...(omit(mergedOptions, interceptors) as typeof mergedOptions),
@@ -65,6 +81,8 @@ export let resolveOptions = <
          defaultOptions.headers,
          fetcherOpts.headers,
       ),
+      reject,
+      parseRejected,
       input: getUrl(
          mergedOptions.baseUrl,
          input,

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export type ParseResponse<TFetchFn extends BaseFetchFn, TParsedData> = (
    options: ResolvedOptions<TFetchFn>,
 ) => MaybePromise<TParsedData>
 
-export type ParseResponseError<TFetchFn extends BaseFetchFn> = (
+export type ParseRejected<TFetchFn extends BaseFetchFn> = (
    res: Response,
    options: ResolvedOptions<TFetchFn>,
 ) => any
@@ -78,23 +78,23 @@ export type ResolvedOptions<
    readonly input: Request | string
    method?: Method
    params: Params
+   parseRejected: ParseRejected<TFetchFn>
    parseResponse: ParseResponse<TFetchFn, TParsedData>
-   parseResponseError: ParseResponseError<TFetchFn>
    rawBody?: TRawBody | null | undefined
+   reject: (response: Response) => MaybePromise<boolean>
    schema?: TSchema
    serializeBody: SerializeBody<TRawBody>
    serializeParams: SerializeParams
    signal?: AbortSignal
-   throwResponseError: (response: Response) => MaybePromise<boolean>
    timeout?: number
 }
 
 export type FallbackOptions<TFetchFn extends BaseFetchFn> = {
+   parseRejected: ParseRejected<TFetchFn>
    parseResponse: ParseResponse<TFetchFn, any>
-   parseResponseError: ParseResponseError<TFetchFn>
+   reject: (response: Response) => MaybePromise<boolean>
    serializeParams: SerializeParams
    serializeBody: SerializeBody<BodyInit | JsonifiableObject | JsonifiableArray>
-   throwResponseError: (response: Response) => MaybePromise<boolean>
 }
 
 /**
@@ -119,17 +119,25 @@ export type DefaultOptions<
    onSuccess?: (data: any, options: ResolvedOptions<TFetchFn>) => void
    /** URL parameters to be serialized and appended to the URL */
    params?: Params
+   /** Function to parse response errors */
+   parseRejected?: ParseRejected<TFetchFn>
    /** Function to parse the response data */
    parseResponse?: ParseResponse<TFetchFn, TDefaultParsedData>
-   /** Function to parse response errors */
-   parseResponseError?: ParseResponseError<TFetchFn>
+   /**
+    * @deprecated Will be renamed `parseRejected` in v2.0
+    */
+   parseResponseError?: ParseRejected<TFetchFn>
+   /** Function to determine if a response should throw an error */
+   reject?: (response: Response) => MaybePromise<boolean>
    /** Function to serialize request body. Restrict the valid `body` type by typing its first argument. */
    serializeBody?: SerializeBody<TDefaultRawBody>
    /** Function to serialize URL parameters */
    serializeParams?: SerializeParams
    /** AbortSignal to cancel the request */
    signal?: AbortSignal
-   /** Function to determine if a response should throw an error */
+   /**
+    * @deprecated Will be renamed `reject` in v2.0
+    */
    throwResponseError?: (response: Response) => MaybePromise<boolean>
    /** Request timeout in milliseconds */
    timeout?: number
@@ -154,10 +162,16 @@ export type FetcherOptions<
    method?: Method
    /** URL parameters */
    params?: Params
+   /** Function to parse response errors */
+   parseRejected?: ParseRejected<TFetchFn>
    /** Function to parse the response data */
    parseResponse?: ParseResponse<TFetchFn, TParsedData>
-   /** Function to parse response errors */
-   parseResponseError?: ParseResponseError<TFetchFn>
+   /**
+    * @deprecated Will be renamed `parseRejected` in v2.0
+    */
+   parseResponseError?: ParseRejected<TFetchFn>
+   /** Function to determine if a response should throw an error */
+   reject?: (response: Response) => MaybePromise<boolean>
    /** JSON Schema for request/response validation */
    schema?: TSchema
    /** Function to serialize request body. Restrict the valid `body` type by typing its first argument. */
@@ -166,7 +180,9 @@ export type FetcherOptions<
    serializeParams?: SerializeParams
    /** AbortSignal to cancel the request */
    signal?: AbortSignal
-   /** Function to determine if a response should throw an error */
+   /**
+    * @deprecated Will be renamed `reject` in v2.0
+    */
    throwResponseError?: (response: Response) => MaybePromise<boolean>
    /** Request timeout in milliseconds */
    timeout?: number

--- a/src/up.spec-d.ts
+++ b/src/up.spec-d.ts
@@ -185,6 +185,12 @@ test('callback types', async () => {
          expectTypeOf(data).toEqualTypeOf<any>()
          expectTypeOf(options).toEqualTypeOf<ResolvedOptions<typeof fetcher>>()
       },
+      parseRejected(res, options) {
+         expectTypeOf(options.test).toEqualTypeOf<number | undefined>()
+         expectTypeOf(res).toEqualTypeOf<Response>()
+         expectTypeOf(options).toEqualTypeOf<ResolvedOptions<typeof fetcher>>()
+         return Promise.resolve(true)
+      },
       parseResponse(res, options) {
          expectTypeOf(options.test).toEqualTypeOf<number | undefined>()
          expectTypeOf(res).toEqualTypeOf<Response>()

--- a/src/up.spec.ts
+++ b/src/up.spec.ts
@@ -39,6 +39,7 @@ describe('up', () => {
       })
    })
 
+   // TODO remove in 2.0
    describe('throwResponseError', () => {
       test('should throw ResponseError by default when response.ok is false', async () => {
          server.use(
@@ -162,6 +163,141 @@ describe('up', () => {
 
          await upfetch('', {
             parseResponseError: async (e) => {
+               expect(catchCount).toBe(1)
+               catchCount++
+               return e
+            },
+         }).catch(() => {
+            expect(catchCount).toBe(2)
+            catchCount++
+         })
+         expect(catchCount).toEqual(3)
+      })
+   })
+
+   describe('reject', () => {
+      test('should throw ResponseError by default when response.ok is false', async () => {
+         server.use(
+            http.get('https://example.com', async () => {
+               return HttpResponse.json({ hello: 'world' }, { status: 400 })
+            }),
+         )
+
+         let catchCount = 0
+
+         let upfetch = up(fetch, (input) => ({
+            baseUrl: 'https://example.com',
+         }))
+
+         await upfetch('').catch((error) => {
+            expect(isResponseError(error)).toEqual(true)
+            catchCount++
+         })
+         expect(catchCount).toEqual(1)
+      })
+
+      test('should not throw when reject returns false', async () => {
+         server.use(
+            http.get('https://example.com', async () => {
+               return HttpResponse.json({ hello: 'world' }, { status: 400 })
+            }),
+         )
+
+         let catchCount = 0
+
+         let upfetch = up(fetch, () => ({
+            baseUrl: 'https://example.com',
+            reject: () => false,
+         }))
+
+         await upfetch('').catch(() => {
+            catchCount++
+         })
+         expect(catchCount).toEqual(0)
+      })
+
+      test('should execute reject before up.parseRejected', async () => {
+         server.use(
+            http.get('https://example.com', async () => {
+               return HttpResponse.json({ hello: 'world' }, { status: 400 })
+            }),
+         )
+
+         let catchCount = 0
+
+         let upfetch = up(fetch, () => ({
+            baseUrl: 'https://example.com',
+            reject: () => {
+               expect(catchCount).toBe(0)
+               catchCount++
+               return true
+            },
+            parseRejected: async (e) => {
+               expect(catchCount).toBe(1)
+               catchCount++
+               return e
+            },
+         }))
+
+         await upfetch('').catch(() => {
+            expect(catchCount).toBe(2)
+            catchCount++
+         })
+         expect(catchCount).toEqual(3)
+      })
+
+      test('should execute reject before upfetch.parseRejected', async () => {
+         server.use(
+            http.get('https://example.com', async () => {
+               return HttpResponse.json({ hello: 'world' }, { status: 400 })
+            }),
+         )
+
+         let catchCount = 0
+
+         let upfetch = up(fetch, () => ({
+            baseUrl: 'https://example.com',
+            reject: () => {
+               expect(catchCount).toBe(0)
+               catchCount++
+               return true
+            },
+         }))
+
+         await upfetch('', {
+            parseRejected: async (e) => {
+               expect(catchCount).toBe(1)
+               catchCount++
+               return e
+            },
+         }).catch(() => {
+            expect(catchCount).toBe(2)
+            catchCount++
+         })
+         expect(catchCount).toEqual(3)
+      })
+
+      test('should support asynchronous reject functions', async () => {
+         server.use(
+            http.get('https://example.com', async () => {
+               return HttpResponse.json({ hello: 'world' }, { status: 400 })
+            }),
+         )
+
+         let catchCount = 0
+
+         let upfetch = up(fetch, () => ({
+            baseUrl: 'https://example.com',
+            reject: async () => {
+               return new Promise((resolve) => {
+                  catchCount++
+                  setTimeout(() => resolve(true), 100)
+               })
+            },
+         }))
+
+         await upfetch('', {
+            parseRejected: async (e) => {
                expect(catchCount).toBe(1)
                catchCount++
                return e
@@ -648,6 +784,7 @@ describe('up', () => {
       })
    })
 
+   // TODO: remove in 2.0
    describe('parseResponseError', () => {
       test('should parse JSON error responses by default', async () => {
          server.use(
@@ -762,6 +899,126 @@ describe('up', () => {
             body: { a: 1 },
             method: 'POST',
             parseResponseError: () => Promise.resolve('from=upfetch'),
+         }).catch((error) => {
+            expect(error).toEqual('from=upfetch')
+         })
+      })
+   })
+
+   describe('parseRejected', () => {
+      test('should parse JSON error responses by default', async () => {
+         server.use(
+            http.get('https://example.com', () => {
+               return HttpResponse.json({ hello: 'world' }, { status: 400 })
+            }),
+         )
+
+         let upfetch = up(fetch, () => ({
+            baseUrl: 'https://example.com',
+         }))
+         await upfetch('').catch((error) => {
+            expect(error.data).toEqual({ hello: 'world' })
+         })
+      })
+
+      test('should parse TEXT error responses by default', async () => {
+         server.use(
+            http.get('https://example.com', () => {
+               return HttpResponse.text('some text', { status: 400 })
+            }),
+         )
+
+         let upfetch = up(fetch, () => ({
+            baseUrl: 'https://example.com',
+         }))
+         await upfetch('').catch((error) => {
+            expect(error.data).toEqual('some text')
+         })
+      })
+
+      test('should provide response and options to parseRejected', async () => {
+         server.use(
+            http.get('https://example.com', () => {
+               return HttpResponse.text('some text', { status: 400 })
+            }),
+         )
+
+         let upfetch = up(fetch, () => ({
+            baseUrl: 'https://example.com',
+            parseRejected(res, options) {
+               expect(res instanceof Response).toEqual(true)
+               expect(options.input).toEqual('https://example.com')
+               return res.text()
+            },
+         }))
+         await upfetch('').catch((error) => {
+            expect(error).toEqual('some text')
+         })
+      })
+
+      test('should execute parseRejected before onError callback', async () => {
+         server.use(
+            http.get('https://example.com', () => {
+               return HttpResponse.text('some text', { status: 400 })
+            }),
+         )
+
+         let count = 1
+
+         let upfetch = up(fetch, () => ({
+            baseUrl: 'https://example.com',
+            parseRejected(res) {
+               expect(count).toEqual(1)
+               count++
+               return res.text()
+            },
+            onError() {
+               expect(count).toEqual(2)
+               count++
+            },
+         }))
+         await upfetch('').catch(() => {
+            expect(count).toEqual(3)
+         })
+      })
+
+      test('should receive error responses with empty body', async () => {
+         server.use(
+            http.get('https://example.com', () => {
+               return new Response(null, { status: 300 })
+            }),
+         )
+
+         let count = 1
+
+         let upfetch = up(fetch, () => ({
+            baseUrl: 'https://example.com',
+            parseRejected(res) {
+               expect(res.body).toEqual(null)
+               expect(count).toEqual(1)
+               count++
+               return Promise.resolve('some error')
+            },
+         }))
+         await upfetch('').catch((error) => expect(error).toEqual('some error'))
+         expect(count).toEqual(2)
+      })
+
+      test('should allow upfetch.parseRejected to override up.parseRejected', async () => {
+         server.use(
+            http.post('https://example.com', async () => {
+               return HttpResponse.json({ hello: 'world' }, { status: 400 })
+            }),
+         )
+
+         let upfetch = up(fetch, () => ({
+            baseUrl: 'https://example.com',
+            parseRejected: () => Promise.resolve('from=up'),
+         }))
+         await upfetch('', {
+            body: { a: 1 },
+            method: 'POST',
+            parseRejected: () => Promise.resolve('from=upfetch'),
          }).catch((error) => {
             expect(error).toEqual('from=upfetch')
          })

--- a/src/up.ts
+++ b/src/up.ts
@@ -48,7 +48,7 @@ export function up<
             throw error
          })
          .then(async (response: Response) => {
-            if (!(await options.throwResponseError(response))) {
+            if (!(await options.reject(response))) {
                let parsed: Awaited<TParsedData>
                try {
                   parsed = await options.parseResponse(response, options)
@@ -70,10 +70,7 @@ export function up<
             } else {
                let respError: any
                try {
-                  respError = await options.parseResponseError(
-                     response,
-                     options,
-                  )
+                  respError = await options.parseRejected(response, options)
                } catch (error: any) {
                   defaultOpts.onError?.(error, options)
                   throw error


### PR DESCRIPTION
Rename error handling options for v2.0 preparation.

This will be a breaking change in v2.0

## Changes

- Deprecate `throwResponseError` in favor of `reject`
- Deprecate `parseResponseError` in favor of `parseRejected`

## Migration Guide

Both options will continue to work in v1.x versions, but users should start migrating to the new names in preparation for v2:

```ts
// 1.0
upfetch({
  throwResponseError: (res) => !res.ok,
  parseResponseError: (res) => new Error(`HTTP Error ${res.status}`)
})

// 2.0
upfetch({
  reject: (res) => !res.ok,
  parseRejected: (res) => new Error(`HTTP Error ${res.status}`)
})
```
