### PR TITLE
Remove requirement for "as const" assertion in default options

### DIFF
--- a/src/tests/types.spec-d.ts
+++ b/src/tests/types.spec-d.ts
@@ -342,13 +342,17 @@ describe('up should accept a fetcher with', () => {
    })
 })
 
-test('up should not be too strict with the default options type', () => {
-   const upfetch = up(fetch, () => ({
+test('Should not need "as const"', () => {
+   const upfetch1 = up(fetch, () => ({
       cache: 'default',
       credentials: 'include',
    }))
 
-   upfetch('', {
-      credentials: 'include',
-   })
+   upfetch1('', { credentials: 'include' })
+
+   // @ts-expect-error invalid option value
+   const upfetch2 = up(fetch, () => ({ credentials: '' }))
+
+   // @ts-expect-error invalid option value
+   upfetch2('', { credentials: 'includes' })
 })

--- a/src/tests/types.spec-d.ts
+++ b/src/tests/types.spec-d.ts
@@ -341,3 +341,10 @@ describe('up should accept a fetcher with', () => {
       upfetch('', {}, {}, '')
    })
 })
+
+test('up should not be too strict with the default options type', () => {
+   up(fetch, () => ({
+      cache: 'default',
+      credentials: 'include',
+   }))
+})

--- a/src/tests/types.spec-d.ts
+++ b/src/tests/types.spec-d.ts
@@ -343,8 +343,12 @@ describe('up should accept a fetcher with', () => {
 })
 
 test('up should not be too strict with the default options type', () => {
-   up(fetch, () => ({
+   const upfetch = up(fetch, () => ({
       cache: 'default',
       credentials: 'include',
    }))
+
+   upfetch('', {
+      credentials: 'include',
+   })
 })

--- a/src/tests/up.spec.ts
+++ b/src/tests/up.spec.ts
@@ -44,3 +44,10 @@ describe('Should receive the upfetch arguments (up to 3)', () => {
       await upfetch(expectedInput, expectedOptions, expectedCtx)
    })
 })
+
+test('Should not be too strict with the default options type', () => {
+   up(fetch, () => ({
+      cache: 'default',
+      credentials: 'include',
+   }))
+})

--- a/src/tests/up.spec.ts
+++ b/src/tests/up.spec.ts
@@ -44,10 +44,3 @@ describe('Should receive the upfetch arguments (up to 3)', () => {
       await upfetch(expectedInput, expectedOptions, expectedCtx)
    })
 })
-
-test('Should not be too strict with the default options type', () => {
-   up(fetch, () => ({
-      cache: 'default',
-      credentials: 'include',
-   }))
-})

--- a/src/types.ts
+++ b/src/types.ts
@@ -238,16 +238,15 @@ export type FetcherOptions<
 }
 
 export type UpFetch<
-   TDefaultParsedData,
-   TDefaultRawBody,
    TFetchFn extends MinFetchFn,
+   TDefaultOptions extends DefaultOptions<MinFetchFn, any, any>,
 > = <
-   TParsedData = TDefaultParsedData,
+   TParsedData = GetDefaultParsedData<TDefaultOptions>,
    TSchema extends StandardSchemaV1<
       TParsedData,
       any
    > = StandardSchemaV1<TParsedData>,
-   TRawBody = TDefaultRawBody,
+   TRawBody = GetDefaultRawBody<TDefaultOptions>,
 >(
    input: Parameters<TFetchFn>[0],
    fetcherOpts?: FetcherOptions<TFetchFn, TSchema, TParsedData, TRawBody>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,14 @@ export type DistributiveOmit<
    TKey extends KeyOf<TObject> | (string & {}),
 > = TObject extends unknown ? Omit<TObject, TKey> : never
 
+type IsNull<T> = [T] extends [null] ? true : false
+
+type IsUnknown<T> = unknown extends T // `T` can be `unknown` or `any`
+   ? IsNull<T> extends false // `any` can be `null`, but `unknown` can't be
+      ? true
+      : false
+   : false
+
 export type MaybePromise<T> = T | Promise<T>
 
 type JsonPrimitive = string | number | boolean | null | undefined
@@ -36,9 +44,7 @@ export type SerializeParams = (params: Params) => string
 
 export type Params = Record<string, any>
 
-export type RawHeaders =
-   | HeadersInit
-   | Record<string, string | number | null | undefined>
+export type HeadersObject = Record<string, string | number | null | undefined>
 
 type Method =
    | 'GET'
@@ -124,6 +130,16 @@ export type FallbackOptions = {
    serializeBody: SerializeBody<DefaultRawBody>
 }
 
+export type GetDefaultParsedData<TDefaultOptions> =
+   TDefaultOptions extends DefaultOptions<MinFetchFn, infer U, any> ? U : never
+
+export type GetDefaultRawBody<TDefaultOptions> =
+   TDefaultOptions extends DefaultOptions<MinFetchFn, any, infer U>
+      ? IsUnknown<U> extends true
+         ? DefaultRawBody
+         : U
+      : never
+
 /**
  * Default configuration options for the fetch client
  */
@@ -135,7 +151,7 @@ export type DefaultOptions<
    /** Base URL to prepend to all request URLs */
    baseUrl?: string
    /** Request headers to be sent with each request */
-   headers?: RawHeaders
+   headers?: HeadersInit | HeadersObject
    /** HTTP method to use for the request */
    method?: Method
    /** Callback executed when the request fails */
@@ -184,7 +200,7 @@ export type FetcherOptions<
    /** Request body data */
    body?: NoInfer<TRawBody> | null | undefined
    /** Request headers */
-   headers?: RawHeaders
+   headers?: HeadersInit | HeadersObject
    /** HTTP method */
    method?: Method
    /** Callback executed when the request fails */

--- a/src/up.ts
+++ b/src/up.ts
@@ -5,8 +5,6 @@ import type {
    DefaultRawBody,
    DistributiveOmit,
    FetcherOptions,
-   GetDefaultParsedData,
-   GetDefaultRawBody,
    MaybePromise,
    MinFetchFn,
    RetryContext,
@@ -39,11 +37,7 @@ export const up =
          fetcherOpts: FetcherOptions<TFetchFn, any, any, any>,
          ctx?: Parameters<TFetchFn>[2],
       ) => MaybePromise<TDefaultOptions> = () => emptyOptions,
-   ): UpFetch<
-      GetDefaultParsedData<TDefaultOptions>,
-      GetDefaultRawBody<TDefaultOptions>,
-      TFetchFn
-   > =>
+   ): UpFetch<TFetchFn, TDefaultOptions> =>
    async (input, fetcherOpts = emptyOptions, ctx) => {
       const defaultOpts = await getDefaultOptions(input, fetcherOpts, ctx)
 

--- a/src/up.ts
+++ b/src/up.ts
@@ -5,6 +5,8 @@ import type {
    DefaultRawBody,
    DistributiveOmit,
    FetcherOptions,
+   GetDefaultParsedData,
+   GetDefaultRawBody,
    MaybePromise,
    MinFetchFn,
    RetryContext,
@@ -25,18 +27,23 @@ const emptyOptions = {} as any
 export const up =
    <
       const TFetchFn extends MinFetchFn,
-      TDefaultParsedData = any,
-      TDefaultRawBody = DefaultRawBody,
+      const TDefaultOptions extends DefaultOptions<
+         TFetchFn,
+         any,
+         any
+      > = DefaultOptions<TFetchFn, any, DefaultRawBody>,
    >(
       fetchFn: TFetchFn,
       getDefaultOptions: (
          input: Parameters<TFetchFn>[0],
          fetcherOpts: FetcherOptions<TFetchFn, any, any, any>,
          ctx?: Parameters<TFetchFn>[2],
-      ) => MaybePromise<
-         DefaultOptions<TFetchFn, TDefaultParsedData, TDefaultRawBody>
-      > = () => emptyOptions,
-   ): UpFetch<TDefaultParsedData, TDefaultRawBody, TFetchFn> =>
+      ) => MaybePromise<TDefaultOptions> = () => emptyOptions,
+   ): UpFetch<
+      GetDefaultParsedData<TDefaultOptions>,
+      GetDefaultRawBody<TDefaultOptions>,
+      TFetchFn
+   > =>
    async (input, fetcherOpts = emptyOptions, ctx) => {
       const defaultOpts = await getDefaultOptions(input, fetcherOpts, ctx)
 
@@ -95,7 +102,7 @@ export const up =
                        fetcherOpts.params,
                        options.serializeParams,
                     ),
-               options,
+               options as any,
             ),
             options.onRequestStreaming,
          )

--- a/src/up.ts
+++ b/src/up.ts
@@ -24,7 +24,7 @@ const emptyOptions = {} as any
 
 export const up =
    <
-      TFetchFn extends MinFetchFn,
+      const TFetchFn extends MinFetchFn,
       TDefaultParsedData = any,
       TDefaultRawBody = DefaultRawBody,
    >(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,16 +1,18 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type {
    DistributiveOmit,
+   HeadersObject,
    JsonifiableArray,
    JsonifiableObject,
    KeyOf,
    Params,
-   RawHeaders,
    SerializeParams,
 } from './types'
 import { ValidationError } from './validation-error'
 
-export const mergeHeaders = (headerInits: (RawHeaders | undefined)[]) => {
+export const mergeHeaders = (
+   headerInits: (HeadersInit | HeadersObject | undefined)[],
+) => {
    const res: Record<string, string> = {}
    headerInits.forEach((init) => {
       // casting `init` to `HeadersInit` because `Record<string, any>` is


### PR DESCRIPTION
Users have to manually add `as const` assertion when providing default options.

The goal of this PR is to infer the default options type as const automatically

```ts
// Before: "as const" is currently required
const upfetch = up(fetch, () => ({ credentials: 'include' }) as const)
```

```ts
// After: "as const" is not needed
const upfetch = up(fetch, () => ({ credentials: 'include' }))
```