### PR TITLE
fix: webkit ReadableStream uploading is not supported bug Something isn't working

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -6,8 +6,9 @@ import type { StreamingEvent } from './types'
  */
 
 const isWebkit =
-   /AppleWebKit/i.test(window.navigator.userAgent) &&
-   !/Chrome/i.test(window.navigator.userAgent)
+   typeof window !== 'undefined' &&
+   /AppleWebKit/i.test(navigator.userAgent) &&
+   !/Chrome/i.test(navigator.userAgent)
 
 export async function toStreamable<R extends Request | Response>(
    reqOrRes: R,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -5,11 +5,16 @@ import type { StreamingEvent } from './types'
  * so we use the ReadableStream reader API directly
  */
 
+const isWebkit =
+   /AppleWebKit/i.test(window.navigator.userAgent) &&
+   !/Chrome/i.test(window.navigator.userAgent)
+
 export async function toStreamable<R extends Request | Response>(
    reqOrRes: R,
    onStream?: (event: StreamingEvent, reqOrRes: R) => void,
 ): Promise<R> {
    const isResponse = 'ok' in reqOrRes
+   if (isWebkit && !isResponse) return reqOrRes
    const body: (Response | Request)['body'] =
       reqOrRes.body || (reqOrRes as any)._bodyInit
    if (!onStream || !body) return reqOrRes


### PR DESCRIPTION
Checks if the browser is webkit based. If so we skip request streaming.

fixes #65 