### PR TITLE
fix: response error when using  `onResponseStreaming` with webkit

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -8,11 +8,20 @@ import type { StreamingEvent } from './types'
 export async function toStreamable<R extends Request | Response>(
    reqOrRes: R,
    onStream?: (event: StreamingEvent, reqOrRes: R) => void,
+   requestBody?: BodyInit | null,
 ): Promise<R> {
    const isResponse = 'ok' in reqOrRes
-   const body: (Response | Request)['body'] =
-      reqOrRes.body || (reqOrRes as any)._bodyInit
-   if (!onStream || !body) return reqOrRes
+
+   // Request
+   if (!onStream || (!isResponse && !requestBody)) return reqOrRes
+
+   // Response
+   const body = isResponse ? (reqOrRes.clone().body || (reqOrRes as any)._bodyInit) : undefined;
+   console.log(reqOrRes)
+   if(isResponse && !body) {
+      return reqOrRes
+   }
+
    const contentLength = reqOrRes.headers.get('content-length')
    let totalBytes: number = +(contentLength || 0)
    // For the Request, when no "Content-Length" header is present, we read the total bytes from the body

--- a/src/up.ts
+++ b/src/up.ts
@@ -105,6 +105,7 @@ export const up =
                options as any,
             ),
             options.onRequestStreaming,
+            options.body
          )
          await options.onRequest?.(request)
 


### PR DESCRIPTION
This PR fixes request failures when using `onResponseStreaming` with WebKit browsers. We should avoid visit `body` before send request. https://github.com/L-Blondy/up-fetch/blob/v2.1.8/src/stream.ts#L13



Since request streaming is not supported, we should provide a fallback option, such as XHR.

<img width="1143" height="600" alt="image" src="https://github.com/user-attachments/assets/cd6ea605-a60e-4695-94d9-0796517a7d67" />


#65 